### PR TITLE
fix: connect method not waiting until user is fully connected

### DIFF
--- a/src/core/AvatarClient.ts
+++ b/src/core/AvatarClient.ts
@@ -81,9 +81,9 @@ export class AvatarClient extends HTTPClient {
     const room = new Room({ adaptiveStream: true });
     this.room = room;
 
-    room.prepareConnection(serverUrl, token);
+    await room.prepareConnection(serverUrl, token);
     this.setupRoomListeners();
-    room.connect(serverUrl, token);
+    await room.connect(serverUrl, token);
     return room;
   }
 


### PR DESCRIPTION
This could lead to race condition for who is implementing the sdk, eg:

Enabling the mic after is connected:

`
await client.connect()
client.enableMicrophone()
`

Doing this rn doesn't work because the connection has not being established yet